### PR TITLE
Fetch Job Cluster Details

### DIFF
--- a/src/components/Clusters/ClusterDetail.tsx
+++ b/src/components/Clusters/ClusterDetail.tsx
@@ -1,5 +1,15 @@
+import { useParams } from 'react-router-dom';
+
+import { useClusterDetails } from '@/hooks/useClusters';
+
 function ClusterDetail() {
-  return <div className="flex h-full flex-col" />;
+  const { clusterId } = useParams();
+  const clusterName = clusterId ? clusterId : 'cluster name not provided';
+  const { data, isLoading } = useClusterDetails(clusterName);
+
+  console.log('isLoading', isLoading, ' - data', data);
+  if (isLoading) return <div className="flex h-full flex-col">Loading...</div>;
+  return <div className="flex h-full flex-col">{data?.name}</div>;
 }
 
 export default ClusterDetail;

--- a/src/components/Clusters/ClusterDetail.tsx
+++ b/src/components/Clusters/ClusterDetail.tsx
@@ -1,13 +1,14 @@
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { useClusterDetails } from '@/hooks/useClusters';
 
 function ClusterDetail() {
-  const { clusterId } = useParams();
-  const clusterName = clusterId ? clusterId : 'cluster name not provided';
+  const navigate = useNavigate();
+  const { clusterId: clusterName = '' } = useParams();
+  if (!clusterName) navigate('/404', { replace: true });
+
   const { data, isLoading } = useClusterDetails(clusterName);
 
-  console.log('isLoading', isLoading, ' - data', data);
   if (isLoading) return <div className="flex h-full flex-col">Loading...</div>;
   return <div className="flex h-full flex-col">{data?.name}</div>;
 }

--- a/src/components/LoadingFallback.tsx
+++ b/src/components/LoadingFallback.tsx
@@ -4,7 +4,7 @@ import mantisImage from '@/assets/images/mantis-logo-full-transparent.png';
 
 function LoadingFallback() {
   return (
-    <div className="flex h-full animate-fade-in flex-col items-center justify-center gap-4">
+    <div className="animate-fade-in flex h-full flex-col items-center justify-center gap-4">
       <img src={mantisImage} className="h-74 w-80" alt="Mantis Logo" />
       <Loader variant="bars" />
     </div>

--- a/src/components/Router/routes/ClustersRoute.tsx
+++ b/src/components/Router/routes/ClustersRoute.tsx
@@ -13,7 +13,7 @@ export default [
   {
     path: AppRoutePaths.CLUSTERS,
     handle: {
-      breadcrumb: 'Jobs',
+      breadcrumb: 'Clusters',
     },
     element: <Clusters />,
     loader() {

--- a/src/components/Router/routes/ClustersRoute.tsx
+++ b/src/components/Router/routes/ClustersRoute.tsx
@@ -30,6 +30,9 @@ export default [
   },
   {
     path: `${AppRoutePaths.CLUSTERS}/:clusterId`,
+    handle: {
+      breadcrumb: 'Cluster Details',
+    },
     meta: {
       breadcrumb: ({ clusterId }: { clusterId: string }) => clusterId,
     },

--- a/src/hooks/useClusters.tsx
+++ b/src/hooks/useClusters.tsx
@@ -2,11 +2,20 @@ import { useQuery } from 'react-query';
 
 import { Queries } from '@/lib/react-query';
 import { REGION_ENVS } from '@/services/BaseService';
-import { fetchJobClusters } from '@/services/JobClusterService';
+import { fetchJobClusterByName, fetchJobClusters } from '@/services/JobClusterService';
 
 export function useClusters() {
   return useQuery({
     queryKey: [Queries.CLUSTERS],
     queryFn: () => fetchJobClusters(REGION_ENVS),
+  });
+}
+
+export function useClusterDetails(clusterName: string) {
+  const shouldFetch = Boolean(clusterName);
+  return useQuery({
+    queryKey: [Queries.CLUSTER_DETAILS, clusterName],
+    queryFn: () => fetchJobClusterByName(REGION_ENVS, clusterName),
+    enabled: shouldFetch,
   });
 }

--- a/src/lib/react-query.ts
+++ b/src/lib/react-query.ts
@@ -13,6 +13,7 @@ export const Queries = {
   AUTH: 'auth',
   JOBS: 'jobs',
   CLUSTERS: 'clusters',
+  CLUSTER_DETAILS: 'clusterDetails',
   ARTIFACTS: 'artifacts',
   SUMMARY: 'summary',
 };

--- a/src/mirage/index.ts
+++ b/src/mirage/index.ts
@@ -80,6 +80,20 @@ export function makeServer(baseUrl: string) {
         } else return new Response(500, { Error: 'No job found with this id.' });
       });
 
+      this.get('/v1/jobClusters/:clusterName', (schema, request) => {
+        const { clusterName } = request.params;
+
+        let targetCluster: Cluster | null = null;
+        schema.db.clusters.forEach((iterCluster: Cluster) => {
+          if (iterCluster.name === clusterName) {
+            targetCluster = iterCluster;
+          }
+        });
+        if (targetCluster !== null) {
+          return targetCluster;
+        } else return new Response(500, { Error: 'No cluster with that cluster name was found' });
+      });
+
       this.delete('/v1/jobs/:jobId', (schema, request) => {
         //Local type as mirage returns "any"
         type MirageJobEntity<T> = T & {

--- a/src/services/JobClusterService.ts
+++ b/src/services/JobClusterService.ts
@@ -50,3 +50,28 @@ export async function fetchJobClusters(
 
   return jobClusters;
 }
+
+export async function fetchJobClusterByName(
+  regionEnvs: EnvRegion[],
+  clusterName: string,
+): Promise<Cluster | null> {
+  if (!clusterName) return null;
+  const clientEntries = getApiClientEntries().filter(({ env, region }) =>
+    regionEnvs.some((item) => item.env === env && item.region === region),
+  );
+
+  const requests = clientEntries.map(({ client }) =>
+    client.get(`api/v1/jobClusters/${clusterName}`).json(),
+  );
+
+  const responses = await Promise.allSettled(requests);
+  const dataReponses = responses.map((response) => {
+    if (response.status === 'fulfilled') {
+      return response.value as Cluster;
+    } else {
+      return null;
+    }
+  });
+
+  return dataReponses[0];
+}

--- a/src/services/JobClusterService.ts
+++ b/src/services/JobClusterService.ts
@@ -51,10 +51,7 @@ export async function fetchJobClusters(
   return jobClusters;
 }
 
-export async function fetchJobClusterByName(
-  regionEnvs: EnvRegion[],
-  clusterName: string,
-): Promise<Cluster | null> {
+export async function fetchJobClusterByName(regionEnvs: EnvRegion[], clusterName: string) {
   if (!clusterName) return null;
   const clientEntries = getApiClientEntries().filter(({ env, region }) =>
     regionEnvs.some((item) => item.env === env && item.region === region),


### PR DESCRIPTION
### Context
Explain context and other details for this pull request.
-> Fetching of JobCluster Details by cluster name as path parameter.

https://user-images.githubusercontent.com/92316166/229708889-99d86f4b-ad11-456e-b258-b107e4c7d8f5.mov

### Problem
I was trying to render `Cluster Details` Page as children of Cluster Page but it didn't render `<ClusterDetails />` component.
```diff
  {
    path: AppRoutePaths.CLUSTERS,
    handle: {
      breadcrumb: 'Clusters',
    },
    element: <Clusters />,
    loader() {
      void queryClient.prefetchQuery(Queries.CLUSTERS, () => fetchJobClusters(REGION_ENVS));
      return {};
    },
+    children: [ {
+       path: `:clusterId`,
+        handle: {
+         breadcrumb: 'Cluster Details',
+        },
+       meta: {
+          breadcrumb: ({ clusterId }: { clusterId: string }) => clusterId,
+        },
+       element: <ClusterDetail />,
+     },
+  ],    
  },

```
### Checklist

- [ ] Added new tests where applicable
- [ ] `yarn test:unit` passes all tests
- [x] `yarn lint` returns no errors
- [x] `yarn build` returns no errors
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
