### PR TITLE
switch to Material Design icon library for consistency in icons

### DIFF
--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button } from '@mantine/core';
-import { FaTimesCircle } from 'react-icons/fa';
+import { MdCancel } from 'react-icons/md';
 
 function ErrorFallback({
   error,
@@ -10,7 +10,7 @@ function ErrorFallback({
 }) {
   return (
     <div className="mx-auto mt-8 flex h-full flex-col gap-4">
-      <Alert icon={<FaTimesCircle size={16} />} title="Something went wrong" color="red">
+      <Alert icon={<MdCancel size={16} />} title="Something went wrong" color="red">
         {error.message}
       </Alert>
       <Button onClick={resetErrorBoundary}>Try again</Button>

--- a/src/components/Files/FilesUpload.tsx
+++ b/src/components/Files/FilesUpload.tsx
@@ -1,6 +1,6 @@
 import { Text, useMantineTheme } from '@mantine/core';
 import { Dropzone, MIME_TYPES } from '@mantine/dropzone';
-import { TbFileCheck, TbFileZip, TbX } from 'react-icons/tb';
+import { MdClose, MdOutlineFolderZip, MdOutlineTask } from 'react-icons/md';
 
 import { uploadArtifacts } from '@/services/ArtifactService';
 import { ENVS } from '@/services/BaseService';
@@ -50,16 +50,16 @@ function FilesUpload() {
       accept={[MIME_TYPES.zip, 'application/json', 'application/java-archive']}
     >
       <Dropzone.Accept>
-        <TbFileCheck
+        <MdOutlineTask
           size={50}
           color={theme.colors[theme.primaryColor][theme.colorScheme === 'dark' ? 4 : 6]}
         />
       </Dropzone.Accept>
       <Dropzone.Reject>
-        <TbX size={50} color={theme.colors.red[theme.colorScheme === 'dark' ? 4 : 6]} />
+        <MdClose size={50} color={theme.colors.red[theme.colorScheme === 'dark' ? 4 : 6]} />
       </Dropzone.Reject>
       <Dropzone.Idle>
-        <TbFileZip size={50} />
+        <MdOutlineFolderZip size={50} />
       </Dropzone.Idle>
 
       <div>

--- a/src/components/Jobs/Jobs.tsx
+++ b/src/components/Jobs/Jobs.tsx
@@ -2,7 +2,7 @@ import type { TypeRowSelection } from '@inovua/reactdatagrid-community/types';
 import { Button, Switch } from '@mantine/core';
 import { useCallback, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { TbServerCog } from 'react-icons/tb';
+import { MdOutlineRepartition } from 'react-icons/md';
 
 import AppLink from '@/components/AppLink';
 import DataGrid from '@/components/DataGrid';
@@ -42,7 +42,7 @@ function Jobs() {
       render: ({ value }: { value: string }) => (
         <AppLink
           className="flex h-full"
-          item={<TbServerCog />}
+          item={<MdOutlineRepartition />}
           to={`/${AppRoutePaths.CLUSTERS}/${getJobClusterId(value)}`}
         />
       ),

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Image, TextInput } from '@mantine/core';
 import { Helmet } from 'react-helmet-async';
 import { useForm } from 'react-hook-form';
-import { TbAt } from 'react-icons/tb';
+import { MdAlternateEmail } from 'react-icons/md';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import mantisImage from '@/assets/images/mantis-logo-full-transparent.png';
@@ -60,7 +60,7 @@ function Login() {
               <TextInput
                 label="Email"
                 placeholder="Enter your email"
-                icon={<TbAt size={14} />}
+                icon={<MdAlternateEmail size={14} />}
                 withAsterisk
                 {...register('email', {
                   required: 'Email required',

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,14 +1,14 @@
 import { Anchor, Menu, createStyles } from '@mantine/core';
 import {
-  AiOutlineCarryOut,
-  AiOutlineCluster,
-  AiOutlineDashboard,
-  AiOutlineFileSync,
-  AiOutlineInfoCircle,
-  AiOutlineLogout,
-  AiOutlineQuestionCircle,
-  AiOutlineUser,
-} from 'react-icons/ai';
+  MdHelpOutline,
+  MdInfoOutline,
+  MdLogout,
+  MdOutlineEventAvailable,
+  MdOutlineFilePresent,
+  MdOutlineLan,
+  MdOutlineSpaceDashboard,
+  MdPersonOutline,
+} from 'react-icons/md';
 import { Link, useMatches, useNavigate } from 'react-router-dom';
 
 import mantisImage from '@/assets/images/mantis-logo-full-transparent.png';
@@ -62,10 +62,10 @@ function TopNav() {
   const { classes } = useStyles();
 
   const links = [
-    { link: AppRoutePaths.JOBS, label: 'Jobs', icon: <AiOutlineCarryOut /> },
-    { link: AppRoutePaths.CLUSTERS, label: 'Clusters', icon: <AiOutlineCluster /> },
-    { link: AppRoutePaths.FILES, label: 'Files', icon: <AiOutlineFileSync /> },
-    { link: AppRoutePaths.SUMMARY, label: 'Summary', icon: <AiOutlineDashboard /> },
+    { link: AppRoutePaths.JOBS, label: 'Jobs', icon: <MdOutlineEventAvailable /> },
+    { link: AppRoutePaths.CLUSTERS, label: 'Clusters', icon: <MdOutlineLan /> },
+    { link: AppRoutePaths.FILES, label: 'Files', icon: <MdOutlineFilePresent /> },
+    { link: AppRoutePaths.SUMMARY, label: 'Summary', icon: <MdOutlineSpaceDashboard /> },
   ];
 
   const items = links.map((link) => {
@@ -94,14 +94,14 @@ function TopNav() {
         <Menu trigger="hover" shadow="md">
           <Menu.Target>
             <div className="flex flex-row items-center gap-2">
-              <AiOutlineQuestionCircle /> Help
+              <MdHelpOutline /> Help
             </div>
           </Menu.Target>
 
           <Menu.Dropdown>
             <Menu.Item
               className={classes.menuItem}
-              icon={<AiOutlineInfoCircle />}
+              icon={<MdInfoOutline />}
               component="a"
               href="https://netflix.github.io/mantis/"
               target="_blank"
@@ -114,14 +114,14 @@ function TopNav() {
         <Menu trigger="hover" shadow="md">
           <Menu.Target>
             <div className="flex flex-row items-center gap-2">
-              <AiOutlineUser /> {user?.name}
+              <MdPersonOutline /> {user?.name}
             </div>
           </Menu.Target>
 
           <Menu.Dropdown>
             <Menu.Item
               className={classes.menuItem}
-              icon={<AiOutlineLogout />}
+              icon={<MdLogout />}
               onClick={() => logout(() => navigate(AppRoutePaths.LOGIN))}
             >
               Log Out

--- a/src/utils/notifications.tsx
+++ b/src/utils/notifications.tsx
@@ -1,5 +1,5 @@
 import { showNotification } from '@mantine/notifications';
-import { TbCheck, TbInfoCircle, TbX } from 'react-icons/tb';
+import { MdClose, MdDone, MdInfoOutline } from 'react-icons/md';
 
 const autoClose = 5000;
 
@@ -8,7 +8,7 @@ export function showInfoNotification(message: string, title?: string) {
     title,
     message,
     autoClose,
-    icon: <TbInfoCircle />,
+    icon: <MdInfoOutline />,
     color: 'gray',
   });
 }
@@ -18,7 +18,7 @@ export function showSuccessNotification(message: string, title?: string) {
     title,
     message,
     autoClose,
-    icon: <TbCheck />,
+    icon: <MdDone />,
     color: 'green',
   });
 }
@@ -28,7 +28,7 @@ export function showErrorNotification(message: string, title?: string) {
     title,
     message,
     autoClose,
-    icon: <TbX />,
+    icon: <MdClose />,
     color: 'red',
   });
 }


### PR DESCRIPTION
### Context
Explain context and other details for this pull request.
<div>
<img width="106" alt="Screenshot 2023-04-22 at 1 33 59 AM" src="https://user-images.githubusercontent.com/92316166/233725025-78e63a49-00b6-4eb8-9072-c5561eaa53a5.png">
<img width="106" alt="Screenshot 2023-04-22 at 1 26 24 AM" src="https://user-images.githubusercontent.com/92316166/233724467-9dc456c4-077c-41e4-a615-5e5de850d47f.png">
<img width="106" alt="Screenshot 2023-04-22 at 1 23 23 AM" src="https://user-images.githubusercontent.com/92316166/233724664-37171a63-c8e4-4bd2-a6f1-e2c790064926.png">
<img width="106" alt="Screenshot 2023-04-22 at 1 24 11 AM" src="https://user-images.githubusercontent.com/92316166/233724708-0a7b6470-2907-4dd4-907a-eb94bc09e94f.png">
<img width="106" alt="Screenshot 2023-04-22 at 1 32 25 AM" src="https://user-images.githubusercontent.com/92316166/233724775-0904de53-4db2-4e56-ab08-f95a21caba4c.png">
<img width="106" alt="Screenshot 2023-04-22 at 1 36 05 AM" src="https://user-images.githubusercontent.com/92316166/233725318-bdcc750e-3d3d-44c1-a6b1-b55118fa8b2c.png">
<img width="106" alt="Screenshot 2023-04-22 at 1 35 37 AM" src="https://user-images.githubusercontent.com/92316166/233725342-3d73bb24-80e8-4ce8-868f-4246d32a7a99.png">
<img width="106" alt="Screenshot 2023-04-22 at 1 37 33 AM" src="https://user-images.githubusercontent.com/92316166/233725544-1cc2a8e7-e412-4a3e-b6ef-2ecc79a85188.png">
<img width="106" alt="Screenshot 2023-04-22 at 1 38 45 AM" src="https://user-images.githubusercontent.com/92316166/233725757-74948e3a-3323-41b3-9685-9ba15e865a27.png">
<img width="106" alt="Screenshot 2023-04-22 at 1 39 53 AM" src="https://user-images.githubusercontent.com/92316166/233725941-1b849f3b-3ce2-45a0-9cb0-0269aabdc595.png">
<img width="106" alt="Screenshot 2023-04-22 at 1 44 05 AM" src="https://user-images.githubusercontent.com/92316166/233726544-6480bddd-22b5-4bad-8544-d5e5a7d56046.png">
</div>

### Checklist
- [ ] Added new tests where applicable
- [ ] `yarn test:unit` passes all tests
- [x] `yarn lint` returns no errors
- [x] `yarn build` returns no errors
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
